### PR TITLE
Fix Yarn version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,5 @@
     "semi": false,
     "endOfLine": "lf",
     "singleQuote": true
-  },
-  "packageManager": "yarn@4.9.2"
+  }
 }


### PR DESCRIPTION
## Summary
- remove the `packageManager` setting so that Corepack uses Yarn 1

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d9915c34832db4a202b8e1fefdb8