### PR TITLE
Use Node 18 for Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
   command = "yarn build"
   functions = "lambda"
 [build.environment]
-  YARN_VERSION = "1.22.4"
+  YARN_VERSION = "4.9.2"
   YARN_FLAGS = "--no-ignore-optional"
-  NODE_VERSION = "16"
+  NODE_VERSION = "18"


### PR DESCRIPTION
## Summary
- update `netlify.toml` so the Netlify build uses Node 18 and Yarn 4.9.2

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6852bff185f0832dbb8bcd3845df371b