### PR TITLE
Fix Node 16 build by removing Yarn Berry config

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,5 @@
     "semi": false,
     "endOfLine": "lf",
     "singleQuote": true
-  },
-  "packageManager": "yarn@4.9.2"
+  }
 }


### PR DESCRIPTION
## Summary
- remove the `packageManager` field so Netlify doesn’t invoke Yarn 4
- drop Berry artifacts (`.yarn/` and `.yarnrc.yml`)

## Testing
- `yarn install` *(succeeded with warnings)*
- `npm test` *(failed to find @testing-library/dom; 21 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852d9ac5ff4832d96e35373ee70899c