### PR TITLE
Set Yarn 1.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ A custom, image-centric theme for Gatsby.
 **Based on [London](https://github.com/TryGhost/London) for Ghost**
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cebiri/MPDS_Then&stack=cms)
+
+## Local Development
+
+This project uses **Yarn 1.x**. Make sure you have at least version `1.22.22`
+installed before running any `yarn` commands.

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,6 @@
   publish = "public"
   command = "yarn build"
 [build.environment]
-  YARN_VERSION = "4.9.2"
+  YARN_VERSION = "1.22.22"
   YARN_FLAGS = "--no-ignore-optional"
   NODE_VERSION = "18"


### PR DESCRIPTION
## Summary
- switch Netlify build environment to Yarn 1.22.22
- document the Yarn requirement for developers

## Testing
- `npx yarn@1.22.22 install --immutable`

------
https://chatgpt.com/codex/tasks/task_e_685394dd4f40832db499cebaee8b85bd